### PR TITLE
[QOLDEV-545] fix profanityfilter version number for newer setuptools

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ here = path.abspath(path.dirname(__file__))
 
 setup(
     name='profanityfilter',
-    version='2.0.6.',
+    version='2.0.6',
     description='A universal Python library for detecting and/or filtering profane words.',
     long_description='For more details visit https://github.com/areebbeigh/profanityfilter',
     url='https://github.com/areebbeigh/profanityfilter',


### PR DESCRIPTION
setuptools is refusing to install profanityfilter, stating that '2.0.6.' is not a valid version number according to PEP440.